### PR TITLE
two-channel mixer

### DIFF
--- a/lib/Engine_TheMachine.sc
+++ b/lib/Engine_TheMachine.sc
@@ -116,8 +116,8 @@ Engine_TheMachine : CroneEngine {
         
         ratio = Sanitize.kr(ratio, 1);
         shiftedSound = amp.lag(0.1)*envUgen*PitchShiftPA.ar(snd, freq: info[0], pitchRatio: ratio, formantRatio: formantRatio, timeDispersion: timeDispersion);
-        pannedSound = Pan2.ar(shiftedSound, pan);
-        Out.ar(out,Pan2.ar(SoundIn.ar(1)));
+        pannedSound = Pan2.ar(shiftedSound, 1);
+        Out.ar(out,Pan2.ar(SoundIn.ar(1),-1));
         Out.ar(out, pannedSound); 
       }).add;    
       

--- a/lib/Engine_TheMachine.sc
+++ b/lib/Engine_TheMachine.sc
@@ -93,7 +93,7 @@ Engine_TheMachine : CroneEngine {
       }).add;
       
       SynthDef(\follower, { |infoBus, minFreq=82, maxFreq=1046|
-        var snd = Mix.ar(SoundIn.ar([0, 1]));
+        var snd = Mix.new(SoundIn.ar(0));
         var reference = LocalIn.kr(1);
         var info = Pitch.kr(snd, minFreq: minFreq, maxFreq: maxFreq);
         var midi = info[0].cpsmidi;
@@ -109,7 +109,7 @@ Engine_TheMachine : CroneEngine {
         var info = DelayN.kr(In.kr(infoBus, 2), delay+0.01, delay);
         var env = Env.asr(0.2);
         var envUgen = EnvGen.kr(env, gate, doneAction: Done.freeSelf);        
-        var snd = DelayN.ar(Mix.ar(SoundIn.ar([0, 1])), delay+0.01, delay);
+        var snd = DelayN.ar(Mix.new(SoundIn.ar(0)), delay+0.01, delay);
         var adjustedTargetHz = (targetHz.cpsmidi.lag(0.05) + (envUgen * Amplitude.kr(snd)*vibratoAmount*SinOsc.kr(vibratoSpeed))).midicps;
         var ratio = (pull*info[1].lag(acquisition).if(adjustedTargetHz/info[0], 1)) + (1 - pull);
         var shiftedSound, pannedSound;
@@ -117,6 +117,7 @@ Engine_TheMachine : CroneEngine {
         ratio = Sanitize.kr(ratio, 1);
         shiftedSound = amp.lag(0.1)*envUgen*PitchShiftPA.ar(snd, freq: info[0], pitchRatio: ratio, formantRatio: formantRatio, timeDispersion: timeDispersion);
         pannedSound = Pan2.ar(shiftedSound, pan);
+        Out.ar(out,Pan2.ar(SoundIn.ar(1)));
         Out.ar(out, pannedSound); 
       }).add;    
       

--- a/sacred_cyborg_harmony.lua
+++ b/sacred_cyborg_harmony.lua
@@ -128,7 +128,6 @@ function init()
   params:add_control("lead acquisition", "acquisition speed", controlspec.new(0.01, 0.5, 'exp', 0, 0.1, "s"))
   params:add_control("lead pan", "pan", controlspec.BIPOLAR)
   
-  
   params:add_separator("cyborg choir")
   local my_delay = controlspec.DELAY:copy()
   my_delay.default = 0.02
@@ -140,6 +139,12 @@ function init()
   params:add_control("keytrack", "formant keytrack", controlspec.new(-1, 2, 'lin', 0, 0.15, ""))
   params:add_control("choir pan", "pan", controlspec.BIPOLAR)
   params:add_option("sensitivity", "velocity sensitivity", {"none", "linear", "square"}, 1)  
+  
+  params:add_separator("input mixer")
+  params:add_control("input chan", "input chan", controlspec.BIPOLAR)
+  params:add_control("pass chan", "pass chan", controlspec.BIPOLAR)
+  params:add_control("pass amp", "pass amp", ampspec)
+  params:add_control("pass pan", "pass pan", controlspec.BIPOLAR)
   
   
   midi_device = {} -- container for connected midi devices
@@ -186,7 +191,12 @@ function process_midi(data)
       params:get("vibrato speed"),
       formant,
       params:get("choir pan"),
-      d.note)
+      d.note,
+      params:get("input chan"),
+      params:get("pass chan"),
+      params:get("pass amp"),
+      params:get("pass pan")
+    )
     screen_dirty = true
     -- print("on", d.note)
   elseif d.type == "note_off" then
@@ -218,7 +228,8 @@ function osc_in(path, args, from)
         -- print("pitch", pitch, "unquant", unquantizedSungNote, "quant", newNote)
         sungNote = newNote
         engine.acceptQuantizedPitch(
-          music.note_num_to_freq(sungNote), params:get("pull"), params:get("lead amp"), params:get("lead formants"), params:get("lead acquisition"), params:get("lead pan"))
+          music.note_num_to_freq(sungNote), params:get("pull"), params:get("lead amp"), params:get("lead formants"), params:get("lead acquisition"), params:get("lead pan"),
+	           params:get("input chan"),params:get("pass chan"),params:get("pass amp"),params:get("pass pan"))
       end
     end
   end


### PR DESCRIPTION
this PR gives a option to pan either of the two channels in the stereo input and gives an option as a "passthrough" channel which is not used for the voice machine. 

for example, this makes it possible to route your instrument into the left channel input, your microphone into the right channel input, and then you can accompany the voice by setting the left to passthrough and the right to be intput to the voice machine.

because it is simply "panning" the 2 input channels you can also create a mixture in case you want the accompaniment to leak into the voice machine or vice versa. 

maybe this is too complicated? happy to make improvements. or you can just close this PR if not needed, because really this script is just perfect as it is :)